### PR TITLE
specify python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull a pre-built alpine docker image with nginx and python3 installed
-FROM python:slim-bookworm
+FROM python:3.11-slim-bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Flask
-gunicorn
-werkzeug
-requests
-Pillow
-pyodbc
-psycopg2-binary
+Flask==3.0.3
+gunicorn==23.0.0
+werkzeug==3.0.4
+requests==2.32.3
+Pillow==10.4.0
+pyodbc==5.2.0
+psycopg2-binary==2.9.10


### PR DESCRIPTION
Currently the base image in dockerfile is using the latest python of version that is causing some issues. Make the switch to specify python version. Also specify version of packages to install in requirements.txt.